### PR TITLE
Change image name to line up with dockerhub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <repository>sdcplatform/${project.artifactId}</repository>
+                            <repository>sdcplatform/sdx-gateway</repository>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
sdx gateway has a different naming convention to all the other repositories. It uses the name `sdx-gateway` instead of the artifact name `sdxgatewaysvc`. I have updated the maven build to produce the image conforming to the name everything else expects.