### PR TITLE
Use java-8-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:8-jre-slim
 
 ARG JAR_FILE=sdxgatewaysvc*.jar
 COPY target/$JAR_FILE /opt/sdx-gateway.jar


### PR DESCRIPTION
Using java 8 slim base image, this should cut the size of the layers by at leave 50%