### PR TITLE
Add instructions for settings up maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,16 @@
 The Survey Data Exchange (SDX) Gateway is a RESTful web service implemented using [Spring Boot](http://projects.spring.io/spring-boot/). It provides an interface for the Survey Data Exchange to notify Response Management when a response has been receipted.
 
 ## Running
-Ensure RabbitMQ is running.
 
+There are two ways of running this service
+
+* The easiest way is via docker (https://github.com/ONSdigital/ras-rm-docker-dev)
+* Alternatively running the service up in isolation
+    ```bash
+    cp .maven.settings.xml ~/.m2/settings.xml  # This only needs to be done once to set up mavens settings file
     mvn clean install
-    ./mvnw spring-boot:run
+    mvn spring-boot:run
+    ```
 
 ### Overriding Credentials
 


### PR DESCRIPTION
## Background
Developers who have recently started working on this project have not been aware that they need to update their local ~/.m2/settings.xml file to be able to build the project.

The service depends on artifacts that are being stored in artifactory.
The instructions that have been added describe how to configure maven
locally for building the project.

## What has changed
Added documentation describing how to start service

## How to review
Check instructions to start service are correct