### PR TITLE
Add stacktrace logging

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,6 +24,16 @@
             }
           </pattern>
         </pattern>
+        <stackTrace>
+          <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+            <maxDepthPerThrowable>30</maxDepthPerThrowable>
+            <maxLength>2048</maxLength>
+            <shortenedClassNameLength>20</shortenedClassNameLength>
+            <exclude>^sun\.reflect\..*\.invoke</exclude>
+            <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+            <rootCauseFirst>true</rootCauseFirst>
+          </throwableConverter>
+        </stackTrace>
       </providers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,7 +27,6 @@
         <stackTrace>
           <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
             <maxDepthPerThrowable>30</maxDepthPerThrowable>
-            <maxLength>2048</maxLength>
             <shortenedClassNameLength>20</shortenedClassNameLength>
             <exclude>^sun\.reflect\..*\.invoke</exclude>
             <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>


### PR DESCRIPTION
# Background
The java services are suppressing their stack traces making it
extremely difficult to troubleshoot issues that occur when running
the services locally or in production. The log configurations
lives with the logback.xml

# What has changed
We use a encoder from logstash (https://github.com/logstash/logstash-logback-encoder\#encoders--layouts)
to generated json formatted logs. There is a built in stacktrace
formatter net.logstash.logback.stacktrace.ShortenedThrowableConverter we are
utilising to format the message.

# How to test
1. Set the logging profile to `CLOUD` via hard coding or configuration
1. Start the service
1. Cause an exception and observe an exception in the logs

Example
```
{"created":"2018-05-21 16:13:21,139","service":"samplesvc","level":"ERROR","event":"Failed to process sample units because {}","stack_trace":"o.p.u.PSQLException: ERROR: permission denied for schema sample\n  Position: 296\n\tat o.p.c.v.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2455)\n\tat o.p.c.v.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2155)\n\tat o.p.c.v.QueryExecutorImpl.execute(QueryExecutorImpl.java:288)\n\tat o.p.jdbc.PgStatement.executeInternal(PgStatement.java:430)\n\tat o.p.jdbc.PgStatement.execute(PgStatement.java:356)\n\tat o.p.j.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:168)\n\tat o.p.j.PgPreparedStatement.executeQuery(PgPreparedStatement.java:116)\n\t... 2 frames excluded\n\tat j.l.reflect.Method.invoke(Method.java:498)\n\tat o.a.t.j.p.StatementFacade$StatementProxy.invoke(StatementFacade.java:114)\n\tat c.s.proxy.$Proxy183.executeQuery(Unknown Source)\n\tat o.h.e.j.i.ResultSetReturnImpl.extract(ResultSetReturnImpl.java:70)\n\t... 56 common frames omitted\nWrapped by: o.h.e.SQLGrammarException: could not extract ResultSet\n\tat o.h.e.i.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:106)\n\tat o.h.e.i.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:42)\n\tat o.h.e.j.s.SqlExceptionHelper.convert(SqlExceptionHelper.java:109)\n\tat o.h.e.j.s.SqlExceptionHelper.convert(SqlExceptionHelper.java:95)\n\tat o.h.e.j.i.ResultSetReturnImpl.extract(ResultSetReturnImpl.java:79)\n\tat o.h.loader.Loader.getResultSet(Loader.java:2117)\n\tat o.h.loader.Loader.executeQueryStatement(Loader.java:1900)\n\tat o.h.loader.Loader.executeQueryStatement(Loader.java:1876)\n\tat o.h.loader.Loader.doQuery(Loader.java:919)\n\tat o.h.loader.Loader.doQueryAndInitializeNonLazyCollections(Loader.java:336)\n\tat o.h.loader.Loader.doList(Loader.java:2617)\n\tat o.h.loader.Loader.doList(Loader.java:2600)\n\tat o.h.loader.Loader.listIgnoreQueryCache(Loader.java:2429)\n\tat o.h.loader.Loader.list(Loader.java:2424)\n\tat o.h.l.h.QueryLoader.list(QueryLoader.java:501)\n\tat o.h.h.i.a.QueryTranslatorImpl.list(QueryTranslatorImpl.java:371)\n\tat o.h.e.q.s.HQLQueryPlan.performList(HQLQueryPlan.java:216)\n\tat o.h.i.SessionImpl.list(SessionImpl.ja..."}
```