### PR TITLE
added userId to casereceipt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.product</groupId>
             <artifactId>casesvc-api</artifactId>
-            <version>10.49.1</version>
+            <version>10.49.35</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/ons/ctp/sdx/domain/Receipt.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/domain/Receipt.java
@@ -14,5 +14,6 @@ import uk.gov.ons.ctp.response.casesvc.message.feedback.InboundChannel;
 public class Receipt {
   @NotBlank private String caseId;
   private String caseRef;
+  private String userId;
   private InboundChannel inboundChannel;
 }

--- a/src/main/java/uk/gov/ons/ctp/sdx/representation/ReceiptDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/representation/ReceiptDTO.java
@@ -12,6 +12,6 @@ import org.hibernate.validator.constraints.NotBlank;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class ReceiptDTO {
   @NotBlank private String caseId;
-  private String userId;
+  @NotBlank private String userId;
   private String caseRef;
 }

--- a/src/main/java/uk/gov/ons/ctp/sdx/representation/ReceiptDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/representation/ReceiptDTO.java
@@ -12,5 +12,6 @@ import org.hibernate.validator.constraints.NotBlank;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class ReceiptDTO {
   @NotBlank private String caseId;
+  private String userId;
   private String caseRef;
 }

--- a/src/main/java/uk/gov/ons/ctp/sdx/service/impl/ReceiptServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/service/impl/ReceiptServiceImpl.java
@@ -41,10 +41,7 @@ public class ReceiptServiceImpl implements ReceiptService {
       caseReceipt.setCaseRef(caseRef.trim());
     }
     caseReceipt.setCaseId((receipt.getCaseId()));
-    String userId = receipt.getUserId();
-    if (userId != null) {
-      caseReceipt.setPartyId(receipt.getUserId());
-    }
+    caseReceipt.setPartyId(receipt.getUserId());
     caseReceipt.setInboundChannel(receipt.getInboundChannel());
 
     try {

--- a/src/main/java/uk/gov/ons/ctp/sdx/service/impl/ReceiptServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/service/impl/ReceiptServiceImpl.java
@@ -41,6 +41,10 @@ public class ReceiptServiceImpl implements ReceiptService {
       caseReceipt.setCaseRef(caseRef.trim());
     }
     caseReceipt.setCaseId((receipt.getCaseId()));
+    String userId = receipt.getUserId();
+    if (userId != null) {
+      caseReceipt.setPartyId(receipt.getUserId());
+    }
     caseReceipt.setInboundChannel(receipt.getInboundChannel());
 
     try {

--- a/src/test/java/uk/gov/ons/ctp/sdx/endpoint/ReceiptEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/ctp/sdx/endpoint/ReceiptEndpointUnitTest.java
@@ -31,15 +31,19 @@ public class ReceiptEndpointUnitTest {
 
   private static final String LOCATION = "Location";
   private static final String CASE_ID = "fa622b71-f158-4d51-82dd-c3417e31e32d";
+  private static final String USER_ID = "fa622b71-f158-4d51-82dd-c3417e31e32f";
   private static final String RECEIPT_INVALIDJSON_SCENARIO1 = "{\"random\":  \"abc\"}";
   private static final String RECEIPT_INVALIDJSON_SCENARIO2 =
       "{\"caseRef\":  \"123\", \"caseId\":\"\"}";
   private static final String BRES_RECEIPT_VALIDJSON =
-      String.format("{\"caseRef\":  \"\", \"caseId\": \"%s\"}", CASE_ID);
+      String.format(
+          "{\"caseRef\":  \"\", \"caseId\": \"%s\", \"userId\": \"%s\"}", CASE_ID, USER_ID);
   private static final String BRES_RECEIPT_VALIDJSON_NO_CASEREF =
-      String.format("{\"caseId\": \"%s\"}", CASE_ID);
+      String.format("{\"caseId\": \"%s\", \"userId\": \"%s\"}", CASE_ID, USER_ID);
   private static final String RECEIPT_VALIDJSON =
-      String.format("{\"caseRef\":  \"%s\", \"caseId\": \"%s\"}", CASE_REF, CASE_ID);
+      String.format(
+          "{\"caseRef\":  \"%s\", \"caseId\": \"%s\", \"userId\": \"%s\"}",
+          CASE_REF, CASE_ID, USER_ID);
   private static final String SERVER_URL = "/receipts";
 
   /** configure the test */


### PR DESCRIPTION
# Motivation and Context
Theres a bug in production at the moment where the receipting is taking the caseid's partyid which is the business party id. This was unexpected as it's hard to test locally so now, SDX-Receipt-rrm passes us the userid which is passed through eQ and SDX. This can then be used in the case events metadata to get the respondents name on Response-operations UI.

# What has changed
- Receipt receiver can now pass through the userid as well as just the caseid.

# How to test?
Need to run with  [Case service PR](https://github.com/ONSdigital/rm-case-service/pull/102)

To test this locally I send a POST request to RM-SDX Gateway at the http://localhost:8191/receipts which includes the caseid and partyid of the respondent which you can get if you debug frontstage when you click `access survey` for an eQ. You need to first make sure an eQ has been set to in progress before you can do this. This can be done by clicking `access survey`.

# Links
[Trello](https://trello.com/c/Hd4vgVp5)
