### PR TITLE
Prevent aggressive sftp polling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM openjdk:8-jre-slim
 
 ARG JAR_FILE=sdxgatewaysvc*.jar
-RUN apt-get update
-RUN apt-get -yq install curl
-RUN apt-get -yq clean
+RUN apt-get update && \
+    apt-get -yq install curl
+
+EXPOSE 8191
+
+HEALTHCHECK --interval=1m30s --timeout=10s --retries=3 \
+  CMD curl -f http://localhost:8191/info || exit 1
+
 COPY target/$JAR_FILE /opt/sdx-gateway.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/sdx-gateway.jar" ]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,7 @@ sftp:
   username: centos
   password: "JLibV2&XD,"
   directory: Documents
-  cron: "* * * * * ?"
+  cron: "0 * * * * ?"
   filepattern: "Receipt*.csv"
   
 data-grid:


### PR DESCRIPTION
# Motivation and Context
When running the service locally it was generating a lot of load on the resources.
The reason behind this was the aggressive polling of an sftp resource, every 1 second. The polling creates a new connection for every check.
Potentially the solution should be to create a connection pool and reuse open connections rather than create a new one each time.

# What has changed
The cron expression has been changed from every 1 second to ever 1 minute

# How to test?
Does it all continue to work as expected? is there a negative for polling less frequently in the dev environment?
