### PR TITLE
change dockerfile user and imagepullpolicy

### DIFF
--- a/_infra/Dockerfile
+++ b/_infra/Dockerfile
@@ -1,9 +1,5 @@
 FROM openjdk:8-jre-slim
 
-RUN groupadd --gid 999 sdxgw && \
-    useradd --create-home --system --uid 999 --gid sdxgw sdxgw
-USER sdxgw
-
 COPY sdxgatewaysvc.jar /opt/sdxgatewaysvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/sdxgatewaysvc.jar" ]

--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "eu.gcr.io/ons-rasrmbs-management/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - name: http-server
               containerPort: 8191


### PR DESCRIPTION
Change the dockerfile user to original until we can investigate alternatives for the java object mapper.

change imagepullpolicy to always
