### PR TITLE
Rabbitmq fix

### DIFF
--- a/_infra/helm/sdx-gateway/Chart.yaml
+++ b/_infra/helm/sdx-gateway/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.19
+appVersion: 11.0.20

--- a/src/main/java/uk/gov/ons/ctp/sdx/config/RabbitMQConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/config/RabbitMQConfig.java
@@ -19,16 +19,16 @@ import org.springframework.retry.support.RetryTemplate;
 
 @Configuration
 public class RabbitMQConfig {
-private String username;
-private String password;
-private String hostname;
-private int port;
-private String virtualHost;
+  private String username;
+  private String password;
+  private String hostname;
+  private int port;
+  private String virtualHost;
 
-@Value("${messaging.pubMaxAttempts}") 
-private int pubMaxAttempts;
+  @Value("${messaging.pubMaxAttempts}") 
+  private int pubMaxAttempts;
 
-    public RabbitMQConfig (
+  public RabbitMQConfig (
         @Value("${rabbitmq.username}") String username,
         @Value("${rabbitmq.password}") String password,
         @Value("${rabbitmq.host}") String hostname,
@@ -106,14 +106,14 @@ private int pubMaxAttempts;
     @Bean
     public Queue caseResponsesQueue() {
         return QueueBuilder.durable("Case.Responses").withArgument("x-dead-letter-exchange", "case-deadletter-exchange")
-                .withArgument("x-dead-letter-routing-key", "Case.Responses.binding").build();
+          .withArgument("x-dead-letter-routing-key", "Case.Responses.binding").build();
     }
 
     // Bindings
     @Bean
-    public Binding xDeadLetterBinding(Queue caseResponsesQueue, DirectExchange caseOutboundExchange) {
+     public Binding xDeadLetterBinding(Queue caseResponsesQueue, DirectExchange caseOutboundExchange) {
     Binding binding = BindingBuilder.bind(caseResponsesQueue).to(caseOutboundExchange)
-        .with("x-dead-letter-routing-key");
+      .with("x-dead-letter-routing-key");
     return binding;
     }
 

--- a/src/main/java/uk/gov/ons/ctp/sdx/config/RabbitMQConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/sdx/config/RabbitMQConfig.java
@@ -73,7 +73,7 @@ private int pubMaxAttempts;
         MarshallingMessageConverter caseReceiptMarshallingMessageConverter) {
         RabbitTemplate caseReceiptRabbitTemplate = new RabbitTemplate(connectionFactory);
         caseReceiptRabbitTemplate.setExchange("case-outbound-exchange");
-        caseReceiptRabbitTemplate.setRoutingKey("Case.Responses.binding");
+        caseReceiptRabbitTemplate.setRoutingKey("x-dead-letter-routing-key");
         caseReceiptRabbitTemplate.setMessageConverter(caseReceiptMarshallingMessageConverter);
         caseReceiptRabbitTemplate.setChannelTransacted(true);
         return caseReceiptRabbitTemplate;
@@ -98,7 +98,7 @@ private int pubMaxAttempts;
     
     // Exchanges
     @Bean
-    DirectExchange caseOutboundExchange() {
+    public DirectExchange caseOutboundExchange() {
         return new DirectExchange("case-outbound-exchange");
     }
 
@@ -111,9 +111,16 @@ private int pubMaxAttempts;
 
     // Bindings
     @Bean
-    public Binding caseResponsesBinding(Queue caseResponsesQueue, DirectExchange caseOutboundExchange) {
+    public Binding xDeadLetterBinding(Queue caseResponsesQueue, DirectExchange caseOutboundExchange) {
     Binding binding = BindingBuilder.bind(caseResponsesQueue).to(caseOutboundExchange)
         .with("x-dead-letter-routing-key");
+    return binding;
+    }
+
+    @Bean
+     public Binding caseResponsesBinding(Queue caseResponsesQueue, DirectExchange caseOutboundExchange) {
+    Binding binding = BindingBuilder.bind(caseResponsesQueue).to(caseOutboundExchange)
+      .with("Case.Responses.binding");
     return binding;
     }
 }


### PR DESCRIPTION
# Motivation and Context
Fix routing keys on Case Responses binding in RabbitMQ, following recent conversion of config from XML to annotation in https://github.com/ONSdigital/rm-sdx-gateway/pull/60. Migration appeared to work OK, but in fact the exchange was being created without the routing keys set correctly. This only shows up when the Case Responses queue is created, so we missed it in preprod testing. 
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Added second binding in RabbitMQ config, set one routing key default in tempalte, and did a bit of tidy-up on the indents
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
- `mvn clean install`
- `mvn spring-boot:run`
- deploy gateway with new image to a sandbox cluster
- run acceptance tests on sandbox cluster 
- set port forwarding from localhost with ras-rm-cli
- `curl -u $USER:$PASSWD -H "Accept: application/json" -H "Content-Type: application/json" http://localhost:8191/receipts -v -X POST -d "{\"userId\":\"ded66326-6365-4eca-afca-12bd2aca7b9b\",\"caseId\": \"069e61fe-8e87-4b50-8af9-3c4a34a643bf\"}"`
- check gateway pod logs for errors, and check Case.Responses queue in RabbitMQ (localhost:15672)
- check that receipting works in frontstage (localhost:8082) and response-ops-ui (localhost:8085)
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
- https://github.com/ONSdigital/rm-sdx-gateway/pull/60
- https://trello.com/c/WIEkDPRE
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
