### PR TITLE
Patch security vulnerability in rm-sdx-gateway

### DIFF
--- a/_infra/helm/sdx-gateway/Chart.yaml
+++ b/_infra/helm/sdx-gateway/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.1
+appVersion: 11.1.2

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
         <javax.activation.version>1.2.0</javax.activation.version>
         <jaxb.api.version>2.3.0</jaxb.api.version>
         <jacoco.version>0.8.5</jacoco.version>
+        <springframework.version>5.2.8.RELEASE</springframework.version>
+        <springboot.version>2.2.8.RELEASE</springboot.version>
     </properties>
 
     <scm>
@@ -54,7 +56,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>5.2.7.RELEASE</version>
+            <version>${springframework.version}</version>
         </dependency>
 
         <dependency>
@@ -128,31 +130,31 @@
         <dependency>
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-rabbit</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jetty</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
@@ -170,31 +172,31 @@
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-core</artifactId>
-            <version>5.2.7.RELEASE</version>
+            <version>${springframework.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-amqp</artifactId>
-            <version>5.2.7.RELEASE</version>
+            <version>${springframework.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-integration</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-xml</artifactId>
-            <version>5.2.7.RELEASE</version>
+            <version>${springframework.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
@@ -213,7 +215,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
-            <version> 2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
@@ -263,14 +265,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <version>2.2.8.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
-            <version>5.2.7.RELEASE</version>
+            <version>${springframework.version}</version>
         </dependency>
 
         <dependency>
@@ -385,7 +387,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.2.8.RELEASE</version>
+                <version>${springboot.version}</version>
                 <configuration>
                     <executable>true</executable>
                     <mainClass>uk.gov.ons.ctp.sdx.Application</mainClass>


### PR DESCRIPTION
# Motivation and Context
Critical vulnerability in spring-integration-core, requires a bump to version 5.2.8 in pom.xml.
-  https://nvd.nist.gov/vuln/detail/CVE-2020-5413
-  https://spring.io/blog/2020/07/22/spring-integration-4-3-23-5-1-12-5-2-8-5-3-2-available-cve-2020-5413
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Bumped Spring Framework a minor version, and moved Spring Framework and Spring Boot versions to properties in pom.xml for easier (and less error-prone) update next time.
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
- `mvn clean install`
- `mvn spring-boot:run`
- deploy gateway with new image to a sandbox cluster
- run acceptance tests on sandbox cluster 
- set port forwarding from localhost with ras-rm-cli
- `curl -u $USER:$PASSWD -H "Accept: application/json" -H "Content-Type: application/json" http://localhost:8191/receipts -v -d "{\"userId\":\"ded66326-6365-4eca-afca-12bd2aca7b9b\",\"caseId\": \"069e61fe-8e87-4b50-8af9-3c4a34a643bf\"}"`
- check gateway pod logs for errors, and check Case.Responses queue in RabbitMQ (localhost:15672)
- check that receipting works in frontstage (localhost:8082) and response-ops-ui (localhost:8085)
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
- https://collaborate2.ons.gov.uk/jira/browse/RAS-198
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
