### PR TITLE
change service resource to have 1 or the other

### DIFF
--- a/_infra/helm/sdx-gateway/Chart.yaml
+++ b/_infra/helm/sdx-gateway/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.1.4
+appVersion: 11.1.5

--- a/_infra/helm/sdx-gateway/templates/service.yaml
+++ b/_infra/helm/sdx-gateway/templates/service.yaml
@@ -13,15 +13,16 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
-  - name: http
-    port: {{ .Values.service.http.port }}
-    targetPort: {{ .Values.container.http.port }}
-    protocol: TCP
-    {{- if eq $.Values.service.type "LoadBalancer" }}
+  {{- if eq $.Values.service.type "LoadBalancer" }}
   - name: https
     port: {{ .Values.service.https.port }}
     targetPort: {{ .Values.container.https.port }}
     protocol: TCP
-    {{- end }}
+  {{- else }}
+  - name: http
+    port: {{ .Values.service.http.port }}
+    targetPort: {{ .Values.container.http.port }}
+    protocol: TCP
+  {{- end }}
   selector:
     app: {{ .Chart.Name }}


### PR DESCRIPTION
SDX gateway is currently accepting http and https. this is becuase the service manifest allows for both is LoadBalancer type is supplied. this PR changes that so only 1 or the other can be acttive.
